### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ git tag -a v1.0.0 -m "Bump to version 1.0.0"
 git push --follow-tags
 ```
 
+**N.B. It is also possible to perform this step by using the [GitHub web interface or CLI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).**
+
 
 ## GitHub actions workflow
 


### PR DESCRIPTION
Although creating tags is now slightly more complicated following the move from `bump2version` to `setuptools_scm`, the updated release mechanism now allows the use of GitHub releases to trigger release to PyPI.

Also, the release tooling in the GitHub CLI is nice if you don't want to use the web interface. 