### PR TITLE
Update PyPI link names

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -201,7 +201,7 @@ def test_docs(package_path_config_dict):
         project_toml = load_pyproject_toml(package_path)
 
         assert (
-            "github.io" in project_toml["project"]["urls"]["documentation"]
+            "github.io" in project_toml["project"]["urls"]["Documentation"]
         ) is true_if_create_docs
 
 
@@ -250,16 +250,16 @@ def test_pyproject_toml(package_path_config_dict):
         f"{config_dict['package_name']}"
     )
 
-    assert project_toml["project"]["urls"]["homepage"] == test_repo_url
+    assert project_toml["project"]["urls"]["Homepage"] == test_repo_url
 
     assert (
-        project_toml["project"]["urls"]["bug_tracker"]
+        project_toml["project"]["urls"]["Bug Tracker"]
         == test_repo_url + "/issues"
     )
 
-    assert project_toml["project"]["urls"]["source_code"] == test_repo_url
+    assert project_toml["project"]["urls"]["Source Code"] == test_repo_url
     assert (
-        project_toml["project"]["urls"]["user_support"]
+        project_toml["project"]["urls"]["User Support"]
         == test_repo_url + "/issues"
     )
 

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 {% elif cookiecutter.create_docs == "no" -%}
 "Documentation" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
 {%- endif %}
-"Source code" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
+"Source Code" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
 "User Support" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}/issues"
 {%- endif %}
 

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -45,15 +45,15 @@ classifiers = [
 
 {% if cookiecutter.github_repository_url != 'provide later' -%}
 [project.urls]
-homepage = "{{ cookiecutter.github_repository_url }}"
-bug_tracker = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}/issues"
+"Homepage" = "{{ cookiecutter.github_repository_url }}"
+"Bug Tracker" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}/issues"
 {% if cookiecutter.create_docs == "yes" -%}
-documentation = "https://{{cookiecutter.github_username_or_organization}}.github.io/{{cookiecutter.package_name}}"
+"Documentation" = "https://{{cookiecutter.github_username_or_organization}}.github.io/{{cookiecutter.package_name}}"
 {% elif cookiecutter.create_docs == "no" -%}
-documentation = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
+"Documentation" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
 {%- endif %}
-source_code = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
-user_support = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}/issues"
+"Source code" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}"
+"User Support" = "https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.package_name}}/issues"
 {%- endif %}
 
 [project.optional-dependencies]


### PR DESCRIPTION
The formatting of PyPI links in `datashuttle` was inherited from here.
I applied the same update as in https://github.com/neuroinformatics-unit/datashuttle/pull/168