### PR TITLE
Fix MANIFEST issues

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
           - id: mypy
             additional_dependencies:
                 - types-setuptools
+    - repo: https://github.com/mgedmin/check-manifest
+      rev: "0.49"
+      hooks:
+          - id: check-manifest
+            additional_dependencies: [setuptools-scm]

--- a/{{cookiecutter.package_name}}/MANIFEST.in
+++ b/{{cookiecutter.package_name}}/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE
 include README.md
+exclude .pre-commit-config.yaml
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-exclude docs *
+recursive-exclude tests *


### PR DESCRIPTION
Just realised that as soon as someone makes a new package using the cookiecutter, they'll run into problems with `check-manifest` complaining. So I added some extra exclusions to `MANIFEST.in`. 

I also added a `check-manifest` pre-commit hook, which will be run after all the other hooks. This way users will be able to catch the annoying manifest errors before the push, and not after (as it currently often happens).
