### PR TITLE
Added the sphinx-sitemap package to generate a xml sitemap for google

### DIFF
--- a/{{cookiecutter.package_name}}/docs/requirements.txt
+++ b/{{cookiecutter.package_name}}/docs/requirements.txt
@@ -5,3 +5,4 @@ pydata-sphinx-theme
 setuptools-scm
 sphinx
 sphinx-autodoc-typehints
+sphinx-sitemap

--- a/{{cookiecutter.package_name}}/docs/source/conf.py
+++ b/{{cookiecutter.package_name}}/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "sphinx-sitemap",
     "myst_parser",
     "nbsphinx",
 ]
@@ -113,6 +114,7 @@ html_theme_options = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html
 github_user = "{{cookiecutter.github_username_or_organization}}"
 html_baseurl = f"https://{github_user}.github.io/{project}"
+sitemap_url_scheme = "{link}"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Google is not indexing the default websites correctly. Generating a sitemap will provide google with all available url paths.

**What does this PR do?**
Adds the sphinx-sitemap package to auto-generate a sitemap on build.

## References
#84 

## How has this PR been tested?
Code tested by building locally and inspecting the sitemap by eye.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)


## Checklist:

- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
