### PR TITLE
drop 3.8 support, add 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py39', 'py310', 'py311]
+target-version = ['py39', 'py310', 'py311']
 skip-string-normalization = false
 line-length = 79
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', 'py311]
 skip-string-normalization = false
 line-length = 79
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

We'd like to move to supporting python 3.11.

**What does this PR do?**

Drops Python 3.8 and adds 3.11 instead in `pyproject.toml` and GH actions workflow.

## References

Closes #38 

## How has this PR been tested?

Checks in CI and locally on my Silicon Mac.

## Is this a breaking change?

If you're using 3.8, yes.

## Does this PR require an update to the documentation?

It's already documented that we follow NEP 29, so no.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
