### PR TITLE
drop 3.8, add 3.11 in template pyproject

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -227,7 +227,7 @@ def test_pyproject_toml(package_path_config_dict):
     )
     assert project_toml["project"]["description"] == "Lets Test CookierCutter"
     assert project_toml["project"]["readme"] == "README.md"
-    assert project_toml["project"]["requires-python"] == ">=3.8.0"
+    assert project_toml["project"]["requires-python"] == ">=3.9.0"
     assert (
         project_toml["project"]["license"]["text"] == "MIT"
     )  # parameterize this? test if url not given?
@@ -236,9 +236,9 @@ def test_pyproject_toml(package_path_config_dict):
         "Development Status :: 2 - Pre-Alpha",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
     ]

--- a/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -92,7 +92,7 @@ exclude = ["tests*"]
 addopts = "--cov={{cookiecutter.module_name}}"
 
 [tool.black]
-target-version = ['py39', 'py310', py311]
+target-version = ['py39', 'py310', 'py311']
 skip-string-normalization = false
 line-length = 79
 

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -126,7 +126,7 @@ select = ["I", "E", "F"]
 fix = true
 
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-*"
+build = "cp39-* cp10-* cp311-*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{cookiecutter.package_name}}"
 authors = [{name = "{{cookiecutter.full_name}}", email= "{{cookiecutter.email}}"}]
 description = "{{cookiecutter.short_description}}"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 {% if cookiecutter.license == "MIT" -%}
@@ -24,9 +24,9 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
     {% if cookiecutter.license == "MIT" -%}
     "License :: OSI Approved :: MIT License",
@@ -92,7 +92,7 @@ exclude = ["tests*"]
 addopts = "--cov={{cookiecutter.module_name}}"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', py311]
 skip-string-normalization = false
 line-length = 79
 
@@ -134,14 +134,14 @@ archs = ["x86_64", "arm64"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{38,39,310}
+envlist = py{39,310,311}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 extras =


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

#88 only moved to NEP 29 for this repo, and was missing updates to template itself.

**What does this PR do?**

## References

Closes #38 

## How has this PR been tested?

Luckily, we already had a good test, so
* when I updated the template pyproject but not the test, the [CI failed as expected](https://github.com/neuroinformatics-unit/python-cookiecutter/actions/runs/6812410743/job/18524701589?pr=89)
```bash
E       AssertionError: assert '>=3.9.0' == '>=3.8.0'
E         - >=3.8.0
E         ?     ^
E         + >=3.9.0
E         ?     ^
```
* when I also updated the test in line with NEP 3.9,[ the CI passed again](https://github.com/neuroinformatics-unit/python-cookiecutter/actions/runs/6812436645?pr=89)

## Is this a breaking change?

NA

## Does this PR require an update to the documentation?

No

## Checklist:

- [NA] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [NA] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
