### PR TITLE
Remove `cibuildwheel`

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -125,12 +125,6 @@ exclude = ["__init__.py","build",".eggs"]
 select = ["I", "E", "F"]
 fix = true
 
-[tool.cibuildwheel]
-build = "cp39-* cp10-* cp311-*"
-
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
-
 [tool.tox]
 legacy_tox_ini = """
 [tox]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

We don't want to have `cibuildwheel` by default.

**What does this PR do?**

Removes options for `cibuildwheel` from `pyproject.toml`

## References

Closes #81, depends on #89

## How has this PR been tested?

Searched all files for occurrences of `cibuildwheel` and removed. Existing tests pass. Not sure how to easily do more than that?

## Is this a breaking change?

In theory, yes, if projects that need cibuildwheel rely on this being here?

## Does this PR require an update to the documentation?

AFAICT `cibuildwheel` was not documented here anyway, so no.

## Checklist:

- [NA] The code has been tested locally
- [NA] Tests have been added to cover all new functionality
- [NA] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
