### PR TITLE
Run CI weekly on `main` 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,3 @@
+## Weekly scheduled run
+
+Tests are run on the `main` branch of the original fork of this repository on a weekly schedule, to ensure the cookiecutter template does not have outdated dependencies.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,17 @@
 name: tests
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch: # for occasional debugging
+  schedule:
+    # Every Sunday at 3 AM
+    - cron: "0 3 * * 0" 	
+
 jobs:
   linting:
+    # scheduled workflows should not run on forks
+    if: (${{ github.event_name == 'schedule' }} && github.repository_owner == 'neuroinformatics-unit') || (${{ github.event_name != 'schedule' }}) 
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/lint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: tests
 
-on: 
+on:
   push:
   pull_request:
   workflow_dispatch: # for occasional debugging
   schedule:
     # Every Sunday at 3 AM
-    - cron: "0 3 * * 0" 	
+    - cron: "0 3 * * 0"
 
 jobs:
   linting:
     # scheduled workflows should not run on forks
-    if: (${{ github.event_name == 'schedule' }} && github.repository_owner == 'neuroinformatics-unit') || (${{ github.event_name != 'schedule' }}) 
+    if: (${{ github.event_name == 'schedule' }} && ${{ github.repository_owner == 'neuroinformatics-unit' }} && ${{ github.ref == 'refs/heads/main' }}) || (${{ github.event_name != 'schedule' }})
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/lint@v1


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We'd like to run our tests regularly, because we rarely make changes to the repo, so we are unlikely to catch dependencies going out of date.

**What does this PR do?**

Adds a GH workflow that triggers the test workflow weekly on Sunday at 3AM only on this repo (not on its forks) and on the `main` branch.

## References

Closes #55 

## How has this PR been tested?

Unfortunately, [newly created scheduled runs are triggered only on the default branch](https://devopsjournal.io/blog/2022/08/12/workflows-not-starting) (for security reasons), so this is difficult to test. I suggest to merge this today and check on Monday whether it was successful?

The changes are based on the [nightly build of libsbml](https://github.com/sbmlteam/libsbml/blob/development/.github/workflows/store-artefact.yml) (where I know it "works"). 


An earlier attempt #91 at triggering the `test` workflow from a different workflow was 
* started because I thought this solution would be more complicated than it turned out.
* abandoned because it didn't work out of the box and felt even more complicated in the end.

## Why should this not run on other forks?

* feels like a waste of energy in case there will be many forks in the future (presumably all ~synced to this one)
* it doesn't feel right to cause extra CI runs on other people's repos when they fork/sync their fork

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Added a sentence to the README of the CI subfolder.

## Checklist:

- [⚠️ ] The code has been tested locally ⚠️ No, explicitly not ⚠️ 
- [NA] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
