### PR TITLE
Add codespell to test contributed here materials against typos, and fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,10 @@ repos:
       hooks:
           - id: black
             args: [--config=pyproject.toml]
+    - repo: https://github.com/codespell-project/codespell
+      # Configuration for codespell is in pyproject.toml
+      rev: v2.2.6
+      hooks:
+      - id: codespell
+        additional_dependencies:
+        - tomli

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It will also set up:
 
 ## Set up
 
-### Installating Cookiecutter
+### Installing Cookiecutter
 
 First, install cookiecutter in your desired environment. Running in the terminal in your environment, with Pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,10 @@ line-length = 79
 exclude = ["__init__.py","build",".eggs"]
 select = ["I", "E", "F"]
 fix = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/{{cookiecutter.package_name}}/docs/source/index.rst
+++ b/{{cookiecutter.package_name}}/docs/source/index.rst
@@ -20,7 +20,7 @@ By default the documentation includes the following sections:
 
 You can create additional sections with narrative documentation,
 by adding new ``.md`` or ``.rst`` files to the ``docs/source`` folder.
-These files shoult start with a level-1 (H1) header,
+These files should start with a level-1 (H1) header,
 which will be used as the section title. Sub-sections can be created
 with lower-level headers (H2, H3, etc.) within the same file.
 


### PR DESCRIPTION
## Description

Fix and prevent future common typos using https://github.com/codespell-project/codespell

Let me know if you want to add support for codespell into the template

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

Typos are there and more might sneak in

**What does this PR do?**

adds pre-commit and github workflow (let me know if I should remove) and fixes some typos

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
