### PR TITLE
Replace select with lint.select in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ line-length = 79
 
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
+exclude = ["__init__.py", "build", ".eggs"]
+lint.select = ["I", "E", "F"]
 fix = true

--- a/{{cookiecutter.package_name}}/docs/requirements.txt
+++ b/{{cookiecutter.package_name}}/docs/requirements.txt
@@ -1,3 +1,4 @@
+-e .
 linkify-it-py
 myst-parser
 nbsphinx
@@ -6,4 +7,3 @@ setuptools-scm
 sphinx
 sphinx-autodoc-typehints
 sphinx-sitemap
--e .

--- a/{{cookiecutter.package_name}}/docs/requirements.txt
+++ b/{{cookiecutter.package_name}}/docs/requirements.txt
@@ -6,3 +6,4 @@ setuptools-scm
 sphinx
 sphinx-autodoc-typehints
 sphinx-sitemap
+-e .

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -121,8 +121,8 @@ ignore = [
 
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
+exclude = ["__init__.py", "build", ".eggs"]
+lint.select = ["I", "E", "F"]
 fix = true
 
 [tool.tox]


### PR DESCRIPTION
This stops ruff from complaining:
> warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
>  - 'select' -> 'lint.select'