### PR TITLE
Replaced select with lint.select in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 79
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
+lint.select = ["I", "E", "F"]
 fix = true
 
 [tool.codespell]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -127,7 +127,7 @@ ignore = [
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
-select = ["I", "E", "F"]
+lint.select = ["I", "E", "F"]
 fix = true
 
 [tool.tox]


### PR DESCRIPTION
This stops ruff from complaining:

> warning: The top-level linter settings are deprecated in favour of their counterparts in the lint section. Please update the following options in pyproject.toml:
>
> - 'select' -> 'lint.select'