### PR TITLE
Replace black with ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,8 @@ repos:
       hooks:
         - id: ruff
           args: [ --config=pyproject.toml ]
-    - repo: https://github.com/psf/black
-      rev: 24.3.0
-      hooks:
-          - id: black
-            args: [--config=pyproject.toml]
+        - id: ruff-format
+          args: [ --config=pyproject.toml ]
     - repo: https://github.com/codespell-project/codespell
       # Configuration for codespell is in pyproject.toml
       rev: v2.2.6

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A tool to automatically create a Python project structure ready to release via G
 It will also set up:
 * A blank `README.md` file
 * A `LICENSE` file
-* Formatting checks using [ruff](https://github.com/charliermarsh/ruff)
-* Autoformatting using [Black](https://black.readthedocs.io/en/stable/)
-* [Pre-commit hooks](https://pre-commit.com/)
+* [Pre-commit hooks](https://pre-commit.com/) to automate linting checks and formatting
 * Automatic versioning using [setuptools_scm](https://github.com/pypa/setuptools_scm)
 * A structure for automated tests using [pytest](https://docs.pytest.org/en/7.0.x/)
 * Automated formatting checks, testing and release using [GitHub actions](https://github.com/features/actions)
@@ -15,24 +13,25 @@ It will also set up:
 **Based on [cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin)**
 
 ## Table of contents
-- [cookiecutter-python](#cookiecutter-python)
-	- [Table of contents](#table-of-contents)
-	- [Set up](#set-up)
-		- [Make it a git repo](#make-it-a-git-repo)
-	- [Add your modules and tests](#add-your-modules-and-tests)
-		- [Add dependencies](#add-dependencies)
-		- [Write tests](#write-tests)
-	- [Before committing your changes](#before-committing-your-changes)
-		- [Run the tests](#run-the-tests)
-		- [Install your package locally](#install-your-package-locally)
-		- [Pre-commit hooks](#pre-commit-hooks)
-	- [Versioning](#versioning)
-		- [Automated versioning](#automated-versioning)
-	- [GitHub actions workflow](#github-actions-workflow)
-	- [Documentation](#documentation)
-		- [Building the documentation locally](#building-the-documentation-locally)
-		- [Publishing the documentation](#publishing-the-documentation)
-		- [Docstrings and API documentation](#docstrings-and-api-documentation)
+- [Table of contents](#table-of-contents)
+- [Set up](#set-up)
+	- [Installing Cookiecutter](#installing-cookiecutter)
+	- [Creating a Cookiecutter project](#creating-a-cookiecutter-project)
+	- [Make it a git repo](#make-it-a-git-repo)
+- [Add your modules and tests](#add-your-modules-and-tests)
+	- [Add dependencies](#add-dependencies)
+	- [Write tests](#write-tests)
+- [Before committing your changes](#before-committing-your-changes)
+	- [Run the tests](#run-the-tests)
+	- [Install your package locally](#install-your-package-locally)
+	- [Pre-commit hooks](#pre-commit-hooks)
+- [Versioning](#versioning)
+	- [Automated versioning](#automated-versioning)
+- [GitHub actions workflow](#github-actions-workflow)
+- [Documentation](#documentation)
+	- [Building the documentation locally](#building-the-documentation-locally)
+	- [Publishing the documentation](#publishing-the-documentation)
+	- [Docstrings and API documentation](#docstrings-and-api-documentation)
 
 ## Set up
 
@@ -223,15 +222,19 @@ add_two_integers(1, 2)
 
 Running `pre-commit install` will set up [pre-commit hooks](https://pre-commit.com/) to ensure the code is
 formatted correctly. Currently, these are:
-* [black](https://black.readthedocs.io/en/stable/) for code structure formatting (maximum line length set to 79)
+* [ruff](https://github.com/charliermarsh/ruff) does a number of jobs, including linting, auto-formatting code (with `ruff-format`), and sorting import statements.
 * [mypy](https://mypy.readthedocs.io/en/stable/index.html) a static type checker
-* [ruff](https://github.com/charliermarsh/ruff) does a number of jobs, including enforcing PEP8 and sorting imports
+* [check-manifest](https://github.com/mgedmin/check-manifest) to ensure that the right files are included in the pip package.
+* [codespell](https://github.com/codespell-project/codespell) to check for common misspellings.
+
 
 These will prevent code from being committed if any of these hooks fail. To run them individually:
 ```bash
-ruff .
-black ./
+ruff check --fix   # Lint all files in the current directory, and fix any fixable errors.
+ruff format		   # Format all files in the current directory.
 mypy -p my_awesome_software
+check-manifest
+codespell
 ```
 
 You can also execute all the hooks using `pre-commit run`. The best time to run this is after you have staged your changes, but before you commit them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
-[tool.black]
-target-version = ['py39', 'py310', 'py311']
-skip-string-normalization = false
-line-length = 79
-
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
+exclude = ["__init__.py", "build", ".eggs"]
 lint.select = ["I", "E", "F"]
 fix = true
+
+[tool.ruff.format]
+docstring-code-format = true # Also format code in docstrings
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -269,7 +269,6 @@ def test_pyproject_toml(package_path_config_dict):
         "pytest-cov",
         "coverage",
         "tox",
-        "black",
         "mypy",
         "pre-commit",
         "ruff",
@@ -295,7 +294,7 @@ def test_pyproject_toml(package_path_config_dict):
         project_toml["tool"]["pytest"]["ini_options"]["addopts"]
         == f"--cov={config_dict['module_name']}"
     )
-    assert project_toml["tool"]["black"]
+    assert project_toml["tool"]["ruff"]
 
     assert "legacy_tox_ini" in project_toml["tool"]["tox"]
 

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -23,10 +23,7 @@ repos:
       rev: v0.3.0
       hooks:
         - id: ruff
-    - repo: https://github.com/psf/black
-      rev: 24.2.0
-      hooks:
-          - id: black
+        - id: ruff-format
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.8.0
       hooks:

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -116,6 +116,8 @@ ignore = [
   "tests/test_unit/",
   "tests/test_integration/",
 ]
+{%- endif %}
+
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -122,13 +122,14 @@ ignore = [
   "tests/test_unit/",
   "tests/test_integration/",
 ]
-{%- endif %}
-
 [tool.ruff]
 line-length = 79
-exclude = ["__init__.py","build",".eggs"]
+exclude = ["__init__.py", "build", ".eggs"]
 lint.select = ["I", "E", "F"]
 fix = true
+
+[tool.ruff.format]
+docstring-code-format = true # Also format code in docstrings (e.g. examples)
 
 [tool.tox]
 legacy_tox_ini = """

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -125,7 +125,17 @@ ignore = [
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]
-lint.select = ["I", "E", "F"]
+lint.select = [
+  "E",   # pycodestyle errors
+  "F",   # Pyflakes
+  "I",   # isort
+  # You can see what all the rules do here: https://docs.astral.sh/ruff/rules/
+  # Some additional ruff rules that might be useful (uncomment to enable)
+  #"UP",  # pyupgrade
+  #"B",   # flake8 bugbear
+  #"SIM", # flake8 simplify
+  #"C90", # McCabe complexity
+]
 fix = true
 
 [tool.ruff.format]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -64,7 +64,6 @@ dev = [
   "pytest-cov",
   "coverage",
   "tox",
-  "black",
   "mypy",
   "pre-commit",
   "ruff",
@@ -95,11 +94,6 @@ addopts = "--cov={{cookiecutter.module_name}}"
 filterwarnings = [
     "error",
 ]
-
-[tool.black]
-target-version = ['py39', 'py310', 'py311']
-skip-string-normalization = false
-line-length = 79
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
- Remove `black` dependency and any related configs from `pyproject.toml` and `pre-commit-config.yaml`
- Use `ruff-format` instead, and configure it in `pyproject.toml` and `pre-commit-config.yaml`
- Update README accordingly
- Add some commented out ruff rules in  the `pyproject.toml` that can be optionally enabled.