### PR TITLE
Add wheel as dependency to check-manifest

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]
-            additional_dependencies: [setuptools-scm]
+            additional_dependencies: [setuptools-scm, wheel]
     - repo: https://github.com/codespell-project/codespell
       # Configuration for codespell is in pyproject.toml
       rev: v2.3.0


### PR DESCRIPTION
### Problem

With Python 3.12, `pre-commit run check-manifest` returns an error of missing dependencies.
<img width="532" alt="image" src="https://github.com/user-attachments/assets/fc7ced72-ffd9-4abe-98a6-630f5a06f54a">

According to [this issue](https://github.com/mgedmin/check-manifest/issues/168) this is due to a change in behaviour in Python 3.12, in which apparently `wheel` is no longer preinstalled with virtualenv / venv. See [release notes](https://docs.python.org/3/whatsnew/3.12.html#ensurepip) too.

### Proposed solution
Option 1: adding `wheel` as an additional dependency in `.pre-commit-config.yaml`. This is implemented in this PR.
```python
  - repo: https://github.com/mgedmin/check-manifest
    rev: "0.49"
    hooks:
        - id: check-manifest
          args: [--no-build-isolation]
          additional_dependencies: [setuptools-scm, wheel]

```

Option 2: specifying a language version for Python in `check-manifest`. Feels less flexible.
```python
  - repo: https://github.com/mgedmin/check-manifest
    rev: "0.49"
    hooks:
        - id: check-manifest
          args: [--no-build-isolation]
          language_version: "3.12"
          additional_dependencies: [setuptools-scm]
```

### Questions
- In [CI](https://github.com/neuroinformatics-unit/actions/blob/main/check_manifest/action.yml), we run `check-manifest` with Python 3.10 and without the `--no-build-isolation` flag. 

- Do we need to make CI and the pre-commit hook more similar? Why do we run the `--no-build-isolation` flag in the pre-commits?

- This is only a problem if the system or python interpreter in the same environment as the pre-commit tool is 3.12, so not sure if we should fix this already?