### PR TITLE
Update precommit config inside package

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -19,11 +19,13 @@ repos:
             args: [--fix=lf]
           - id: requirements-txt-fixer
           - id: trailing-whitespace
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: v0.6.3
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.7.2
       hooks:
         - id: ruff
+          args: [ --config=pyproject.toml ]
         - id: ruff-format
+          args: [ --config=pyproject.toml ]
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.10.1
       hooks:

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.6.0
+      rev: v5.0.0
       hooks:
           - id: check-docstring-first
           - id: check-executables-have-shebangs

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
         - id: ruff-format
           args: [ --config=pyproject.toml ]
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.10.1
+      rev: v1.13.0
       hooks:
           - id: mypy
             additional_dependencies:
                 - types-setuptools
     - repo: https://github.com/mgedmin/check-manifest
-      rev: "0.49"
+      rev: "0.50"
       hooks:
           - id: check-manifest
             args: [--no-build-isolation]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
To update the versions in the pre-commit file inside the package.

**What does this PR do?**
It updates the precommit config in the package. Specifically:
-  ruff precommit following PR #127
- `pre-commit-hooks` (version was outdated)
- `mypy` and `check-manifest` hooks, which don't get updated automatically.

## References
PR #127 

It would be nice to automate this as mentioned in #95 - ARC python cookiecutter seems to be using Renovate for this (see example [here](https://github.com/UCL-ARC/python-tooling/pull/485/files)). Will add this info to the issue.
