### PR TITLE
Pin setuptools lower bound to >v64

### DIFF
--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -276,7 +276,7 @@ def test_pyproject_toml(package_path_config_dict):
     ]
 
     assert project_toml["build-system"]["requires"] == [
-        "setuptools>=45",
+        "setuptools>=64",
         "wheel",
         "setuptools_scm[toml]>=6.2",
     ]

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -272,13 +272,13 @@ def test_pyproject_toml(package_path_config_dict):
         "mypy",
         "pre-commit",
         "ruff",
-        "setuptools_scm",
+        "setuptools-scm",
     ]
 
     assert project_toml["build-system"]["requires"] == [
         "setuptools>=64",
         "wheel",
-        "setuptools_scm[toml]>=6.2",
+        "setuptools-scm[toml]>=8",
     ]
 
     assert (

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -67,14 +67,14 @@ dev = [
   "mypy",
   "pre-commit",
   "ruff",
-  "setuptools_scm",
+  "setuptools-scm",
 ]
 
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=64",
     "wheel",
-    "setuptools_scm[toml]>=6.2",
+    "setuptools-scm[toml]>=8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -95,7 +95,7 @@ filterwarnings = [
     "error",
 ]
 
-[tool.setuptools_scm]
+[tool.setuptools-scm]
 
 [tool.check-manifest]
 {% if cookiecutter.create_docs == "yes" -%}

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=64",
     "wheel",
     "setuptools_scm[toml]>=6.2",
 ]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
 
 [build-system]
 requires = [
-    "setuptools>=64",
+    "setuptools>=45",
     "wheel",
     "setuptools_scm[toml]>=6.2",
 ]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -95,7 +95,7 @@ filterwarnings = [
     "error",
 ]
 
-[tool.setuptools-scm]
+[tool.setuptools_scm]
 
 [tool.check-manifest]
 {% if cookiecutter.create_docs == "yes" -%}


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
setuptools>=64: Addresses the editable install issue by setting the lower bound to v64

**What does this PR do?**
updates setup tools version 

## References
#136 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
