### PR TITLE
Use importlib.metadata for package version retrieval in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+-e .
 linkify-it-py
 myst-parser
 nbsphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
--e .
+-e . # required to build API docs
 linkify-it-py
 myst-parser
 nbsphinx

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -12,7 +12,8 @@ body .bd-article-container {
 max-width: 100em !important;
 }
 /* Custom CSS for the documentation site */
-/* prevent logo from being to wide and text clashing with next item */
+/* prevent logo from being too wide and text clashing with next item */
+/* See https://github.com/pydata/pydata-sphinx-theme/issues/1143#issuecomment-2468763375 */
 
 .navbar-header-items__start .navbar-item {
   width: 100%;

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -11,6 +11,29 @@ html[data-theme=light] {
 body .bd-article-container {
 max-width: 100em !important;
 }
+/* Custom CSS for the documentation site */
+/* prevent logo from being to wide and text clashing with next item */
+
+.navbar-header-items__start .navbar-item {
+  width: 100%;
+}
+
+.navbar-item .navbar-brand {
+  width: 100%;
+}
+
+.navbar-brand img {
+  min-width: 0;
+  height: auto;
+  max-height: 100%;
+  flex-shrink: 1;
+}
+
+.navbar-brand p {
+  flex: 0 1 auto;
+}
+
+/* sponsors */
 
 .col {
 flex: 0 0 50%;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,13 +1,14 @@
 # conf.py
 # Configuration file for the Sphinx documentation builder.
-import setuptools_scm
+from importlib.metadata import version as get_version
 
 
 project = "python-cookiecutter"
 copyright = "2025, University College London"
 author = "Neuroinformatics Unit"
+
 try:
-    full_version = setuptools_scm.get_version(root="../..", relative_to=__file__)
+    full_version = get_version(project)
     # Splitting the release on '+' to remove the commit hash
     release = full_version.split('+', 1)[0]
 except LookupError:
@@ -84,6 +85,7 @@ html_theme_options = {
         },
     ],
     "logo": {
+        # The release version can be included here if desired later by using f"{project} {release}"
         "text": f"{project}",
     },
     "footer_start": ["footer_start"],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,8 +85,7 @@ html_theme_options = {
         },
     ],
     "logo": {
-        # The release version can be included here if desired later by using f"{project} {release}"
-        "text": f"{project} {release}",
+        "text": f"{project} v{release}",
     },
     "footer_start": ["footer_start"],
     "footer_end": ["footer_end"],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ html_theme_options = {
     ],
     "logo": {
         # The release version can be included here if desired later by using f"{project} {release}"
-        "text": f"{project}",
+        "text": f"{project} {release}",
     },
     "footer_start": ["footer_start"],
     "footer_end": ["footer_end"],

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -53,6 +53,7 @@ If you are contributing to the Documentation, Before pushing your changes, you c
     the docs:
 
     ``` sh
+     # Must execute from project root directory
     pip install -r docs/requirements.txt
     sphinx-build docs/source docs/build
     ```
@@ -61,7 +62,7 @@ Alternatively, you can use the following commands to install the
 dependencies and build the docs:
 
  ``` sh
-pip install -r docs/requirements.txt
+pip install -r docs/requirements.txt  # Must execute this command from project root directory
 cd docs
 make html
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
+[project]
+name = "python-cookiecutter"
+authors = [{ name = "Neuroinformatics Unit" }]
+description = "A tool to automatically create a Python project structure ready to release via GitHub and PyPI."
+readme = "README.md"
+dynamic = ["version"]
+
+license = { text = "BSD-3-Clause" }
+
+[build-system]
+requires = [
+    "setuptools>=64",
+    "wheel",
+    "setuptools-scm[toml]>=8",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
 [tool.ruff]
 line-length = 79
 exclude = ["__init__.py", "build", ".eggs"]

--- a/{{cookiecutter.package_name}}/docs/requirements.txt
+++ b/{{cookiecutter.package_name}}/docs/requirements.txt
@@ -1,3 +1,4 @@
+-e .
 linkify-it-py
 myst-parser
 nbsphinx

--- a/{{cookiecutter.package_name}}/docs/requirements.txt
+++ b/{{cookiecutter.package_name}}/docs/requirements.txt
@@ -1,4 +1,4 @@
--e .
+-e . # required to build API docs
 linkify-it-py
 myst-parser
 nbsphinx

--- a/{{cookiecutter.package_name}}/docs/source/conf.py
+++ b/{{cookiecutter.package_name}}/docs/source/conf.py
@@ -9,7 +9,7 @@
 import os
 import sys
 
-import setuptools_scm
+from importlib.metadata import version as get_version
 
 # Used when building API docs, put the dependencies
 # of any class you are documenting here
@@ -24,7 +24,9 @@ project = "{{cookiecutter.package_name}}"
 copyright = "2022, {{cookiecutter.full_name}}"
 author = "{{cookiecutter.full_name}}"
 try:
-    release = setuptools_scm.get_version(root="../..", relative_to=__file__)
+    full_version = get_version(project)
+    # Splitting the release on '+' to remove the commit hash
+    release = full_version.split('+', 1)[0]
 except LookupError:
     # if git is not initialised, still allow local build
     # with a dummy version


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

This PR updates the documentation configuration (`docs/source/conf.py`) to retrieve the version using `importlib.metadata.version`.

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

This change aligns with the recommended usage from [setuptools-scm documentation](https://setuptools-scm.readthedocs.io/en/latest/usage/) for retrieving the version. It replaces the direct call to setuptools_scm.get_version with importlib.metadata.

**What does this PR do?**

This PR replaces the `setuptools_scm `version retrieval in `docs/source/conf.py` with the use of `importlib.metadata`. The `get_version` function is imported from `importlib.metadata`

## References

Please reference any existing issues/PRs that relate to this PR.

Fixes #144 
Fixes #102 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

Local build

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.
No
## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.
No
## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
