### PR TITLE
Remove hard-coded organization in website build action

### DIFF
--- a/.github/workflows/docs_build_and _deploy.yml
+++ b/.github/workflows/docs_build_and _deploy.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   linting:
     # scheduled workflows should not run on forks
-    if: (${{ github.event_name == 'schedule' }} && ${{ github.repository_owner == 'neuroinformatics-unit' }} && ${{ github.ref == 'refs/heads/main' }}) || (${{ github.event_name != 'schedule' }})
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/lint@v2


### PR DESCRIPTION


## Description

**What is this PR**

- [ ] Bug fix

**Why is this PR needed?**
This repository is a cookiecutter template, but the docs build workflow hard-codes the neuroinformatics-unit organization. This prevents scheduled workflows from running correctly for downstream users who generate projects from this template.

**What does this PR do?**
Removes the hard-coded organization check from the GitHub Actions condition and instead restricts scheduled runs to the main branch only. This preserves safety while making the workflow reusable for any repository owner.

## References
Fixes #125

## How has this PR been tested?

The change is limited to a GitHub Actions conditional. The logic was verified by inspecting the workflow condition and ensuring it behaves identically for non-scheduled events while enabling scheduled runs for downstream repositories.
## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [ ] The code has been tested locally
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
