### PR TITLE
Add CI-related env variables to tox configuration

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -150,6 +150,7 @@ python =
     3.13: py313
 
 [testenv]
+passenv =
     CI
     GITHUB_ACTIONS
 extras =


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other (configuration)

**Why is this PR needed?**
- When running tests via ```tox```, CI-related environment variables such as ```CI``` and ```GITHUB_ACTIONS``` are not available inside the tox environment by default.

**What does this PR do?**
- It adds ```CI``` and ```GITHUB_ACTIONS``` to the ```passenv``` configuration in the ```legacy_tox_ini``` section.
As a result, these standard CI environment variables are forwarded into tox test environments.

## References
- Addresses: #146 

## How has this PR been tested?
- Tests were run locally using ```pytest```

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
