### PR TITLE
Add tox-gh-actions for the gh-actions segment not to be ignored

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -129,6 +129,9 @@ docstring-code-format = true # Also format code in docstrings (e.g. examples)
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+requires =
+    tox>=4
+    tox-gh-actions
 envlist = py{311,312,313}
 isolated_build = True
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
I think this change is needed so that the tox `gh-actions` segment is not ignored.

**What does this PR do?**

## References

See https://github.com/neuroinformatics-unit/movement/pull/261

## How has this PR been tested?

Checks pass on CI.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ n/a ] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
