### PR TITLE
Remove duplicated check manifest step in workflow

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
@@ -14,14 +14,8 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/lint@v2
 
-  manifest:
-    name: Check Manifest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: neuroinformatics-unit/actions/check_manifest@v2
-
   test:
-    needs: [linting, manifest]
+    needs: [linting]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The MANIFEST.ini file is checked in the linting step already, as specified in the pre-commit config file. Therefore I think this extra step in the workflow is redundant. Let me know if I am missing something.

**What does this PR do?**
Removes the check manifest job in the test_and_deploy workflow

## References

\

## How has this PR been tested?
CI checks

## Is this a breaking change?

\
## Does this PR require an update to the documentation?
\

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
