### PR TITLE
Fix check manifest syntax

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -89,7 +89,7 @@ filterwarnings = [
 [tool.check-manifest]
 {% if cookiecutter.create_docs == "yes" -%}
 ignore = [
-  ".yaml",
+  "*.yaml",
   "tox.ini",
   "tests/",
   "tests/test_unit/",
@@ -99,7 +99,7 @@ ignore = [
 ]
 {% elif cookiecutter.create_docs == "no" -%}
 ignore = [
-  ".yaml",
+  "*.yaml",
   "tox.ini",
   "tests/",
   "tests/test_unit/",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It seems that check-manifest matches ignore patterns with fnmatch against the file path, and ".yaml" (no wildcard) only matches a file literally named .yaml

**What does this PR do?**
Fixes the yaml pattern for check manifest

## References

\

## How has this PR been tested?

\
## Is this a breaking change?

\
## Does this PR require an update to the documentation?

\
## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
