### PR TITLE
Configure PyPI releases via trusted publishing

### DIFF
--- a/docs/source/infrastructure.md
+++ b/docs/source/infrastructure.md
@@ -123,6 +123,7 @@ Releases are published using [trusted publishing](https://docs.pypi.org/trusted-
 * If your package is **already on PyPI**, [add the publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) under the "Publishing" section of your existing project's settings.
 
 In both cases, the **workflow name** must match the one used in this repo: `test_and_deploy.yml`.
+The **environment name** should also match the one specified in the workflow file (`pypi` by default).
 
 :::{tip}
 The `pypi` [GitHub environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) is created by GitHub on the first tagged release. It comes without any protection rules by default, meaning that the only thing preventing an untagged commit from being published is the workflow file itself. As an additional protection, you can also restrict the environment to `v*` tags, by going to the settings of your repository and, under the "Environments" section, adding a deployment tag rule. If you prefer the [GitHub CLI](https://cli.github.com/):

--- a/docs/source/infrastructure.md
+++ b/docs/source/infrastructure.md
@@ -111,7 +111,7 @@ It is also possible to perform this step by using the [GitHub web interface or C
 A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set up to run on each commit/PR:
 * Linting checks (pre-commit).
 * Testing (only if linting checks pass)
-* Release to PyPI (only if a git tag is present and if tests pass). This requires [trusted publishing](#trusted-publishing-on-pypi) to be set up, and the tag must follow the `vX.Y.Z` format.
+* Release to PyPI (only if a git tag is present and if tests pass). This requires [trusted publishing](#trusted-publishing-on-pypi) to be set up.
 
 This automation ensures that each commit or pull request is validated and that releases are published only when all checks pass.
 
@@ -119,18 +119,10 @@ This automation ensures that each commit or pull request is validated and that r
 
 Releases are published using [trusted publishing](https://docs.pypi.org/trusted-publishers/), which is the method recommended by PyPI.
 
-If your package is not on PyPI yet, you will need to [create the project through a "pending" publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), i.e. a trusted publisher that you register before the project exists and that creates it the first time it is used. Go to the ["Publishing" page](https://pypi.org/manage/account/publishing/) of your PyPI account settings and fill in the GitHub form as follows:
+* If your package is **not on PyPI yet**, [create the project through a "pending" publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), i.e. a trusted publisher that you register before the project exists and that creates it the first time it is used.
+* If your package is **already on PyPI**, [add the publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) under the "Publishing" section of your existing project's settings.
 
-* PyPI Project Name: `<package_name>`
-* Owner: `<github_username_or_organization>`
-* Repository name: `<package_name>`
-* Workflow name: `test_and_deploy.yml`
-* Environment name: `pypi`
-
-:::{note}
-- Bear in mind that a "pending" publisher does not reserve your project name on PyPI — the name is only claimed once you make your first release.
-- If your package is already on PyPI, you don't need a "pending" publisher. Instead, [add the publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) under the "Publishing" section of your existing project's settings, using the same values as above.
-:::
+In both cases, the **workflow name** must match the one used in this repo: `test_and_deploy.yml`.
 
 :::{tip}
 The `pypi` [GitHub environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) is created by GitHub on the first tagged release. It comes without any protection rules by default, meaning that the only thing preventing an untagged commit from being published is the workflow file itself. As an additional protection, you can also restrict the environment to `v*` tags, by going to the settings of your repository and, under the "Environments" section, adding a deployment tag rule. If you prefer the [GitHub CLI](https://cli.github.com/):

--- a/docs/source/infrastructure.md
+++ b/docs/source/infrastructure.md
@@ -108,12 +108,47 @@ It is also possible to perform this step by using the [GitHub web interface or C
 
 # GitHub actions workflow
 
-A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set up to run (on each commit/PR):
+A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set up to run on each commit/PR:
 * Linting checks (pre-commit).
 * Testing (only if linting checks pass)
-* Release to PyPI (only if a git tag is present and if tests pass). Requires `TWINE_API_KEY` from PyPI to be set in repository secrets.
+* Release to PyPI (only if a git tag is present and if tests pass). This requires [trusted publishing](#trusted-publishing-on-pypi) to be set up, and the tag must follow the `vX.Y.Z` format.
 
 This automation ensures that each commit or pull request is validated and that releases are published only when all checks pass.
+
+## Trusted publishing on PyPI
+
+Releases are published using [trusted publishing](https://docs.pypi.org/trusted-publishers/), which is the method recommended by PyPI.
+
+If your package is not on PyPI yet, you will need to [create the project through a "pending" publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), i.e. a trusted publisher that you register before the project exists and that creates it the first time it is used. Go to the ["Publishing" page](https://pypi.org/manage/account/publishing/) of your PyPI account settings and fill in the GitHub form as follows:
+
+* PyPI Project Name: `<package_name>`
+* Owner: `<github_username_or_organization>`
+* Repository name: `<package_name>`
+* Workflow name: `test_and_deploy.yml`
+* Environment name: `pypi`
+
+:::{note}
+- Bear in mind that a "pending" publisher does not reserve your project name on PyPI — the name is only claimed once you make your first release.
+- If your package is already on PyPI, you don't need a "pending" publisher. Instead, [add the publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) under the "Publishing" section of your existing project's settings, using the same values as above.
+:::
+
+:::{tip}
+The `pypi` [GitHub environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) is created by GitHub on the first tagged release. It comes without any protection rules by default, meaning that the only thing preventing an untagged commit from being published is the workflow file itself. As an additional protection, you can also restrict the environment to `v*` tags, by going to the settings of your repository and, under the "Environments" section, adding a deployment tag rule. If you prefer the [GitHub CLI](https://cli.github.com/):
+
+```sh
+REPO=<github_username_or_organization>/<package_name>
+
+# Create the environment with custom ref policies enabled
+gh api -X PUT "repos/$REPO/environments/pypi" --input - <<'EOF'
+{"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
+EOF
+
+# Restrict it to v* tags
+gh api -X POST "repos/$REPO/environments/pypi/deployment-branch-policies" --input - <<'EOF'
+{"name":"v*","type":"tag"}
+EOF
+```
+:::
 
 # Documentation
 

--- a/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/test_and_deploy.yml
@@ -49,7 +49,14 @@ jobs:
     name: Publish build distributions
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
+    environment: # use Trusted Publisher route
+      name: pypi
+      url: https://pypi.org/p/${{ github.event.repository.name }}
+    permissions:
+      id-token: write # mandatory for trusted publishing
     steps:
-    - uses: neuroinformatics-unit/actions/upload_pypi@v2
+    - uses: actions/download-artifact@v8
       with:
-        secret-pypi-key: ${{ secrets.TWINE_API_KEY }}
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

See #173, https://github.com/neuroinformatics-unit/actions/issues/76 and  https://github.com/neuroinformatics-unit/poseinterface/pull/67 for context.

**What does this PR do?**

- Updates the `test_and_deploy.yml` workflow to use trusted publishing
- Documents the trusted publishing route in the docs (under the existing "Infrastructure" page).

## References

- Closes #173 
- Follows the example of https://github.com/neuroinformatics-unit/poseinterface/pull/67
- Related to https://github.com/neuroinformatics-unit/actions/issues/76

## How has this PR been tested?

The new publishing route has been tested in `poseinterface` following https://github.com/neuroinformatics-unit/poseinterface/pull/67.

## Is this a breaking change?

N/A

## Does this PR require an update to the documentation?

Yes, the docs have been updated. I locally built the sphinx website to check the rendering.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
